### PR TITLE
Fix an Rails error output in submitting_a_link_post.md

### DIFF
--- a/book/types_of_tests/feature_specs/submitting_a_link_post.md
+++ b/book/types_of_tests/feature_specs/submitting_a_link_post.md
@@ -344,7 +344,7 @@ Define the controller class. We get this failure:
 ```
 Failure/Error: visit root_path
 NoMethodError:
-  undefined method `action' for LinksController:Class
+  undefined method `index' for LinksController:Class
 ```
 
 Hmm, so this one's a bit more cryptic. It's saying that `action` is undefined


### PR DESCRIPTION
Rails is smart enough to know the action name by looking at `config/routes.rb`:

```
root to: "links#index"
```
