### PR TITLE
Make `bin/build` compatible with Paperback 0.2.0

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker run -v $PWD:/book thoughtbot/paperback build "$@"
+docker run -v $PWD:/src thoughtbot/paperback build "$@"


### PR DESCRIPTION
Paperback changed the `WORKDIR` from `/book` to `/src` in the `0.2.0`
release. The relevant commit on Paperback is:
https://github.com/thoughtbot/paperback/commit/5c1a1181a338fa76860f2479decd81e8614204c8

This change updates the `bin/release` command to use `/src` instead of
`/book`. This fixes path errors that occurred when trying to build the
book with Paperback 0.2.0.

This change is probably incompatible with Paperback 0.1.0 and users of
the older version should upgrade.
