### PR TITLE
Pull in dependencies for release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -8,7 +8,7 @@ find build \
   -exec cp -Rv {} release/ \;
 
 # https://github.com/pbrisbin/vbump
-tag="$(git tag | ../vbump/bin/vbump "${1:-patch}")"
+tag="$(git tag | ./bin/vbump "${1:-patch}")"
 git add release
 git commit -m "Releasing $tag"
 git tag -m "$tag" "$tag"

--- a/bin/vbump
+++ b/bin/vbump
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# pbrisbin 2015
+# modified version of https://github.com/pbrisbin/vbump
+#
+# This script depends on the `gsort` (GNU sort) and `gsed` (GNU sed) commands. If
+# they are not found, the script will attempt to install them via homebrew (OSX
+# package manager)
+#
+###
+err_usage() {
+  printf "error: %s\n" "$*" >&2
+  echo 'usage: vbump [major|minor|patch]' >&2
+  exit 64
+}
+
+split() {
+  local pattern='s/v\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)\(.*\)/\1 \2 \3 \4/'
+
+  gsort -rV | head -n 1 | gsed "$pattern"
+}
+
+bump() {
+  local major minor patch
+
+  read major minor patch _
+
+  case "$1" in
+    major)
+      major=$((major + 1))
+      minor=0
+      patch=0
+      ;;
+    minor)
+      minor=$((minor + 1))
+      patch=0
+      ;;
+    patch)
+      patch=$((patch + 1))
+      ;;
+
+    *) err_usage "invalid component: \`$1'" ;;
+  esac
+
+  printf "v%s.%s.%s\n" $major $minor $patch
+}
+
+if ! command -v gsort > /dev/null; then
+  brew install coreutils
+fi
+
+split | bump "${1:-patch}"


### PR DESCRIPTION
We cannot assume the following dependencies of the release script to be
installed already:
- `../vbump/bin/vbump`
- GNU `sort`
- GNU `sed`

`vbump` is a utility for intelligently bumping version numbers. The
release script assumed that  the `vbump` project would be cloned onto
the author's machine as a sibling of the book repo.

Instead, I copied the script as `bin/vbump` to distribute it with the
other utilities of the book repo. Unfortunately, the script required
versions of `sort` and `sed` that were not installed by default on OSX.

They can be downloaded on OSX via the homebrew `coreutils` package as
`gsort` and `gsed`. I modified the script to use these and to attempt to
install `coreutils` via homebrew if they are not detected on the system.

This will likely break on Linux machines unless they have a `gsort`
command that points to the correct version of GNU `sort`
