### PR TITLE
Fix a typo in submitting a link post feature spec example

### DIFF
--- a/book/types_of_tests/feature_specs/submitting_a_link_post.md
+++ b/book/types_of_tests/feature_specs/submitting_a_link_post.md
@@ -155,7 +155,7 @@ the id is for real, and replace it here.
 With the fields filled in, we can submit the form!
 
 ```ruby
-click_on "Shorten!"
+click_on "Submit!"
 ```
 
 And, finally, the assertion:


### PR DESCRIPTION
Should be `Submit!` instead of `Shorten!`.

Ref. [spec/features/user_submits_a_link_spec.rb#L12](https://github.com/thoughtbot/testing-rails/blob/19e77101e30f69dc94defec93abe676ee933db90/example_app/spec/features/user_submits_a_link_spec.rb#L12)
