### PR TITLE
Fix an extra space before the comma

### DIFF
--- a/book/types_of_tests/feature_specs/viewing_the_homepage.md
+++ b/book/types_of_tests/feature_specs/viewing_the_homepage.md
@@ -180,8 +180,8 @@ definition and persists it to the database.
 config.include FactoryGirl::Syntax::Methods
 ```
 
-While we'll be calling `.create` in the global context to keep our code cleaner
-, you may see people calling it more explicitly: `FactoryGirl.create`. This is
+While we'll be calling `.create` in the global context to keep our code cleaner,
+you may see people calling it more explicitly: `FactoryGirl.create`. This is
 simply a matter of preference, and both are acceptable.
 
 Now, we'll need to add a factory definition for our `Link` class in


### PR DESCRIPTION
This pull request fixes the extra space between `cleaner` and `,`:

<img width="624" alt="screenshot 2015-09-06 02 00 44" src="https://cloud.githubusercontent.com/assets/1000669/9700598/32924bec-543b-11e5-9294-35740bf02a99.png">
