### PR TITLE
Discuss alternate terminology

### DIFF
--- a/book/intermediate_testing/testing_in_isolation.md
+++ b/book/intermediate_testing/testing_in_isolation.md
@@ -49,6 +49,8 @@ TDD the SUT even if collaborating components haven't been built yet.
 
 <<[intermediate_testing/testing_in_isolation/testing_side_effects.md]
 
+<<[intermediate_testing/testing_in_isolation/terminology.md]
+
 <<[intermediate_testing/testing_in_isolation/benefits.md]
 
 <<[intermediate_testing/testing_in_isolation/a_pragmatic_approach.md]

--- a/book/intermediate_testing/testing_in_isolation/terminology.md
+++ b/book/intermediate_testing/testing_in_isolation/terminology.md
@@ -1,0 +1,19 @@
+### Terminology
+
+The testing community has a lot of overlapping nomenclature when it comes to the
+techniques for testing things in isolation. For example many refer to fake
+objects that stand in for collaborators (**doubles**) as **mock objects** or
+**test stubs** (not to be confused with **mocking** and **stubbing**).
+
+RSpec itself added to the confusion by providing `stub` and `mock` aliases for
+`double` in older versions (not to be confused with **mocking** and
+**stubbing**).
+
+Forcing a real collaborator to return a canned response to certain messages
+(**stubbing**) is sometimes referred to as a **partial double**.
+
+Finally, RSpec provides a `spy` method which creates a **double** that will
+respond to any method. Although often used when **spying**, these can be used
+anywhere you'd normally use a standard double and any double can be used when
+spying. They term **spy** can be a bit ambiguous as it can refer to both
+objects created via the `spy` method and objects used for spying.

--- a/book/intermediate_testing/testing_in_isolation/test_doubles.md
+++ b/book/intermediate_testing/testing_in_isolation/test_doubles.md
@@ -15,12 +15,3 @@ responds to the following interface:
 
 * `upvotes`
 * `downvotes`
-
-### Historical note
-
-Older versions of RSpec had methods named `stub` and `mock` as aliases to
-`double`. This is particularly confusing because **mocking** and **stubbing**
-are entirely different concepts (more on them later). To make things worse,
-RSpec also monkeypatched `Object` with an `Object.stub` method which *did* do
-real stubbing. You shouldn't run into these unless you are working with a legacy
-test suite.


### PR DESCRIPTION
A lot of the terminology surrounding testing in isolation has synonyms
or can be used in slightly different ways and contexts. This adds a
section to clarify some of that.
