### PR TITLE
Rename `FactoryGirl` to `FactoryBot`

### DIFF
--- a/book/antipatterns/slow_tests.md
+++ b/book/antipatterns/slow_tests.md
@@ -83,15 +83,15 @@ database adds up when running your entire suite.
 When you initialize new objects, try to do so with the least overhead. Depending
 on what you need, you should choose your initialization method in this order:
 
-* `Object.new` - initializes the object without FactoryGirl. Use this when you
+* `Object.new` - initializes the object without FactoryBot. Use this when you
   don't care about any validations or default values.
-* `FactoryGirl.build_stubbed(:object)` - initializes the object with
-  FactoryGirl, setting up default values and associates records using the
+* `FactoryBot.build_stubbed(:object)` - initializes the object with
+  FactoryBot, setting up default values and associates records using the
   `build_stubbed` method. Nothing is persisted to the database.
-* `FactoryGirl.build(:object)` - initializes the object with FactoryGirl,
+* `FactoryBot.build(:object)` - initializes the object with FactoryBot,
   setting up default values and persisting associated records with `create`.
-* `FactoryGirl.create(:object)` - initializes and persists the object with
-  FactoryGirl, setting up default values and persisting associated records with
+* `FactoryBot.create(:object)` - initializes and persists the object with
+  FactoryBot, setting up default values and persisting associated records with
   `create`.
 
 Another thing to look out for is factory definitions with more associations than

--- a/book/types_of_tests/feature_specs/viewing_the_homepage.md
+++ b/book/types_of_tests/feature_specs/viewing_the_homepage.md
@@ -66,7 +66,7 @@ whether or not the user is a member of a specific organization. All these are
 possible states a user can be in and grow the number of fixtures you will have to
 recall.
 
-#### FactoryGirl
+#### FactoryBot
 
 We've found factories to be a better alternative to fixtures. Rather than
 defining hardcoded data, factories define generators of sorts, with predefined
@@ -75,7 +75,7 @@ the factories in your tests. They look something like this:
 
 ```ruby
 # spec/factories.rb
-FactoryGirl.define do
+FactoryBot.define do
   factory :link do
     title "Testing Rails"
     url "http://testingrailsbook.com"
@@ -96,14 +96,15 @@ what is happening at a glance and are more flexible to different scenarios you
 may want to set up. While factories can be slower than fixtures, we think the
 benefits in flexibility and readability outweigh the costs.
 
-#### Installing FactoryGirl
+#### Installing FactoryBot
 
-To install FactoryGirl, add `factory_girl_rails` to your `Gemfile`:
+To install FactoryBot (formerly FactoryGirl), add `factory_bot_rails` to your
+`Gemfile`:
 
 ```ruby
 group :development, :test do
   ...
-  gem "factory_girl_rails"
+  gem "factory_bot_rails"
   ...
 end
 ```
@@ -118,21 +119,24 @@ group :test do
 end
 ```
 
-Install the new gems and create a new file `spec/support/factory_girl.rb`:
+Install the new gems and create a new file `spec/support/factory_bot.rb`.
+
+**Note:** _ Older versions of this library were named `FactoryGirl` and the file
+was named `factory_girl.rb`.
 
 ` spec/support/factory_girl.rb@944b0967
 
 This file will lint your factories before the test suite is run. That is, it
 will ensure that all the factories you define are valid. While not necessary,
 this is a worthwhile check, especially while you are learning. It's a quick way
-to rest easy that your factories work. Since `FactoryGirl.lint` may end up
+to rest easy that your factories work. Since `FactoryBot.lint` may end up
 persisting some records to the database, we use Database Cleaner to restore the
 state of the database after we've linted our factories. We'll cover Database
 Cleaner in depth later.
 
 Now, this file won't require itself! In your `rails_helper` you'll find some
 commented out code that requires all of the files in `spec/support`. Let's
-comment that in so our FactoryGirl config gets loaded:
+comment that in so our FactoryBot config gets loaded:
 
 ```ruby
 # Uncomment me!
@@ -143,7 +147,7 @@ Last, we need to create our factories file. Create a new file at
 `spec/factories.rb`:
 
 ```ruby
-FactoryGirl.define do
+FactoryBot.define do
 end
 ```
 
@@ -151,7 +155,7 @@ This is where we'll define our factory in the next section.
 
 #### The test
 
-With FactoryGirl set up, we can write our test. We start with a new file at
+With FactoryBot set up, we can write our test. We start with a new file at
 `spec/features/user_views_homepage_spec.rb`.
 
 ```ruby
@@ -170,18 +174,18 @@ blocks.
 link = create(:link)
 ```
 
-To setup our test, we create a link using FactoryGirl's `.create` method, which
+To setup our test, we create a link using FactoryBot's `.create` method, which
 instantiates a new `Link` object with our (currently non-existent) factory
 definition and persists it to the database.
 
-`.create` is loaded into the global context in `spec/support/factory_girl.rb`:
+`.create` is loaded into the global context in `spec/support/factory_bot.rb`:
 
 ```
-config.include FactoryGirl::Syntax::Methods
+config.include FactoryBot::Syntax::Methods
 ```
 
 While we'll be calling `.create` in the global context to keep our code cleaner,
-you may see people calling it more explicitly: `FactoryGirl.create`. This is
+you may see people calling it more explicitly: `FactoryBot.create`. This is
 simply a matter of preference, and both are acceptable.
 
 Now, we'll need to add a factory definition for our `Link` class in
@@ -190,7 +194,7 @@ Now, we'll need to add a factory definition for our `Link` class in
 ` spec/factories.rb@944b0967:2,5
 
 We define a default title and URL to be created for all links created with
-FactoryGirl. We only define defaults for fields that we [validate presence of]. If
+FactoryBot. We only define defaults for fields that we [validate presence of]. If
 you add more than that, your factories can become unmanageable as all of your
 tests become coupled to data defined in your factories that isn't a default.
 Not following this advice is a common mistake in Rails codebases and leads to

--- a/book/types_of_tests/helper_specs/formatting_the_score.md
+++ b/book/types_of_tests/helper_specs/formatting_the_score.md
@@ -6,7 +6,7 @@ as a helper method. In TDD fashion we start with a test:
 ` spec/helpers/application_helper_spec.rb@6335cb210b8e83f5
 
 Since we don't need to persist to the database and don't care about validity, we
-are using `Link.new` here instead of `FactoryGirl`.
+are using `Link.new` here instead of `FactoryBot`.
 
 Helpers are modules. Because of this, we can't instantiate them to test inside a
 spec, instead they must be mixed into an object. RSpec helps us out here by

--- a/book/types_of_tests/model_specs/instance_methods.md
+++ b/book/types_of_tests/model_specs/instance_methods.md
@@ -21,7 +21,7 @@ behavior as a string. Typically, we'll use the name of our method, in this case
 link = build(:link, upvotes: 1)
 ```
 
-`.build` is another FactoryGirl method. It's similar to `.create`, in that it
+`.build` is another FactoryBot method. It's similar to `.create`, in that it
 instantiates an object based on our factory definition, however `.build` does
 not save the object. Whenever possible, we're going to favor `.build` over
 `.create`, as persisting to the database is one of the slowest operations in our
@@ -54,10 +54,10 @@ downvote count, then compare the expected and actual scores.
 
 ` spec/models/link_spec.rb@d4001c148:28,34
 
-In this test, you'll notice that we forgo FactoryGirl and use plain ol'
+In this test, you'll notice that we forgo FactoryBot and use plain ol'
 ActiveRecord to instantiate our object. `#score` depends on `#upvotes` and
 `#downvotes`, which we can set without saving our object. Since we never have to
-save our object, we don't need FactoryGirl to set up a valid record.
+save our object, we don't need FactoryBot to set up a valid record.
 
 With a failing test, we can write our implementation:
 

--- a/book/types_of_tests/request_specs/creating_links.md
+++ b/book/types_of_tests/request_specs/creating_links.md
@@ -4,7 +4,7 @@ Next, we'll test creating a new link via our API:
 
 ` spec/requests/api/v1/links_spec.rb@8ca37400a:23,43
 
-`attributes_for` is another FactoryGirl method, which gives you a hash of the
+`attributes_for` is another FactoryBot method, which gives you a hash of the
 attributes defined in your factory. In this case, it would return:
 
 ```
@@ -17,7 +17,7 @@ indicates that the request succeeded in creating a new record. We then check
 that the last `Link` has the title we expect to ensure it is creating a record
 using the data we submitted.
 
-In the second test, we introduce a new FactoryGirl concept called traits. Traits
+In the second test, we introduce a new FactoryBot concept called traits. Traits
 are specialized versions of factories. To declare them, you nest them under
 a factory definition. This will give them all the attributes of the parent
 factory, as well as any of the modifications specified in the trait. With the

--- a/example_app/Gemfile
+++ b/example_app/Gemfile
@@ -13,7 +13,7 @@ gem "active_model_serializers", "~> 0.8.0"
 
 group :development, :test do
   gem "byebug"
-  gem "factory_girl_rails"
+  gem "factory_bot_rails"
   gem "rspec-rails", "~> 3.0"
   gem "shoulda-matchers"
   gem "spring"

--- a/example_app/Gemfile.lock
+++ b/example_app/Gemfile.lock
@@ -68,10 +68,10 @@ GEM
       mail (~> 2.6.3)
     erubis (2.7.0)
     execjs (2.5.0)
-    factory_girl (4.5.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.5.0)
-      factory_girl (~> 4.5.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     globalid (0.3.4)
       activesupport (>= 4.1.0)
@@ -187,7 +187,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   database_cleaner
   email_spec
-  factory_girl_rails
+  factory_bot_rails
   jquery-rails
   rails (= 4.2.1)
   rspec-rails (~> 3.0)

--- a/example_app/spec/factories.rb
+++ b/example_app/spec/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :link do
     title "Testing Rails"
     url "http://testingrailsbook.com"

--- a/example_app/spec/support/factory_girl.rb
+++ b/example_app/spec/support/factory_girl.rb
@@ -1,10 +1,10 @@
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do
     begin
       DatabaseCleaner.start
-      FactoryGirl.lint
+      FactoryBot.lint
     ensure
       DatabaseCleaner.clean
     end


### PR DESCRIPTION
The `FactoryGirl` gem was
[renamed](https://robots.thoughtbot.com/factory_bot) to `FactoryBot`.
This commit goes through and replaces all references to `FactoryGirl`
and `factory_girl` in the book and example app.

Some parts of the book refer to older commits in the example app. In
these places, I've added a note saying the gem was formerly called
`FactoryGirl`.