### PR TITLE
Fixing for Rails 5

### DIFF
--- a/example_app/spec/requests/api/v1/links_spec.rb
+++ b/example_app/spec/requests/api/v1/links_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "POST /api/v1/links" do
   it "creates the link" do
     link_params = attributes_for(:link)
 
-    post "/api/v1/links", link: link_params
+    post "/api/v1/links", params: { link: link_params }
 
     expect(response.status).to eq 201
     expect(Link.last.title).to eq link_params[:title]
@@ -34,7 +34,7 @@ RSpec.describe "POST /api/v1/links" do
     it "returns a 422, with errors" do
       link_params = attributes_for(:link, :invalid)
 
-      post "/api/v1/links", link: link_params
+      post "/api/v1/links", params: { link: link_params }
 
       expect(response.status).to eq 422
       expect(json_body.fetch("errors")).not_to be_empty


### PR DESCRIPTION
According to https://stackoverflow.com/a/46677347/58049 it is no more possible to do a POST like this: `post "/api/v1/links", link: link_params`.
Must be called with `params` keyword:
`post "/api/v1/links", params: { link: link_params }`